### PR TITLE
Disabling Modules in Pod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zendesk-chat",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "React Native Wrapper around Zopim Zendesk Chat",
   "main": "index.js",
   "repository": {

--- a/react-native-zendesk-chat.podspec
+++ b/react-native-zendesk-chat.podspec
@@ -12,6 +12,10 @@ Pod::Spec.new do |s|
   s.source         = { :git => "https://github.com/brandingbrand/react-native-zendesk-chat.git" }
   s.source_files   = 'ios/*.{h,m}'
 
+  s.pod_target_xcconfig = {
+    'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) MODULES_DISABLED=1',
+  }
+
   s.dependency 'React'
   s.dependency 'ZDCChat'
 end


### PR DESCRIPTION
ZDCChat pod does not work when included as a framework. This change explicitly disables modules allowing ZDCChat to resolve ZDCChatAPI