### PR TITLE
Fixing Pod Name for Private Scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brandingbrand/react-native-zendesk-chat",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "React Native Wrapper around Zopim Zendesk Chat",
   "main": "index.js",
   "repository": {

--- a/react-native-zendesk-chat.podspec
+++ b/react-native-zendesk-chat.podspec
@@ -2,7 +2,7 @@ require 'json'
 package = JSON.parse(File.read("package.json"))
 
 Pod::Spec.new do |s|
-  s.name           = package["name"]
+  s.name           = package["name"].split("/").last
   s.version        = package["version"]
   s.summary        = package['description']
   s.author         = "Branding Brand"


### PR DESCRIPTION
Pod names cannot contain slashes. This change extracts the name of the package from the private scope.