### PR TITLE
chore: upgrade Android dependency version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,5 +29,5 @@ repositories {
 
 dependencies {
     compile "com.facebook.react:react-native:+"
-    compile group: 'com.zopim.android', name: 'sdk', version: '1.3.0.1'
+    compile group: 'com.zopim.android', name: 'sdk', version: '1.3.7.1'
 }


### PR DESCRIPTION
getting AAPT: Attribute "layout_anchorGravity" already defined with incompatible format error when building Android with flagship version 3.X. Updated the dependency version so that code is compatible with flagship 3.X.


