### PR TITLE
chore: upgrade com.zopim.android:sdk version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,5 +29,5 @@ repositories {
 
 dependencies {
     compile "com.facebook.react:react-native:+"
-    compile group: 'com.zopim.android', name: 'sdk', version: '1.3.7.1'
+    compile group: 'com.zopim.android', name: 'sdk', version: '1.4.2'
 }


### PR DESCRIPTION
## Issue
Getting com.android.builder.internal.aapt.v2.Aapt2Exception: Android resource compilation failed when building Android with Flagship 4.X. Upgrade com.zopim.android:sdk version to 1.4.2 to make it compatible with Flagship 4.